### PR TITLE
docker compose で bind volume をやめて watch するようにする

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,6 +3,15 @@ version: "3"
 tasks:
   up:
     desc: 開発サーバーを起動します
-    dir: packages/akane-next
     cmds:
-      - npm run dev
+      - docker compose up -w
+
+  down:
+    desc: 開発サーバーを停止します
+    cmds:
+      - docker compose down --remove-orphans
+
+  build:
+    desc: 開発サーバーのイメージをビルドします
+    cmds:
+      - docker compose build

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,3 @@
-volumes:
-  bundle_cache:
-  node_modules:
-
 networks:
   akane:
 
@@ -10,9 +6,15 @@ services:
     build:
       context: packages/akane-next
       dockerfile: ../../docker/akane-next/Dockerfile
-    volumes:
-      - node_modules:/app/node_modules
-      - ./packages/akane-next:/app
     command: ["npm", "run", "dev"]
     ports:
       - "3000:3000"
+    develop:
+      watch:
+        - action: sync
+          path: ./packages/akane-next
+          target: /app
+          ignore:
+            - node_modules
+        - action: rebuild
+          path: package.json

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,3 @@
-networks:
-  akane:
-
 services:
   akane-next:
     build:

--- a/packages/akane-next/src/components/ui/color-mode.tsx
+++ b/packages/akane-next/src/components/ui/color-mode.tsx
@@ -7,6 +7,9 @@ import type { ThemeProviderProps } from "next-themes"
 import * as React from "react"
 import { LuMoon, LuSun } from "react-icons/lu"
 
+// TODO(eslint-rule): 型同士の等式にすることでLintエラーは解決できるが、
+// 今後 ColorModeProviderProps のプロパティが追加されそうなので一時的に無効化している
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ColorModeProviderProps extends ThemeProviderProps {}
 
 export function ColorModeProvider(props: ColorModeProviderProps) {
@@ -45,6 +48,9 @@ export function ColorModeIcon() {
   return colorMode === "dark" ? <LuMoon /> : <LuSun />
 }
 
+// TODO(eslint-rule): 型同士の等式にすることでLintエラーは解決できるが、
+// 今後 ColorModeButtonProps のプロパティが追加されそうなので一時的に無効化している
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface ColorModeButtonProps extends Omit<IconButtonProps, "aria-label"> {}
 
 export const ColorModeButton = React.forwardRef<


### PR DESCRIPTION
# Pull request

- Issues: 

## :question: 背景 (Why)

Docker Compose で Next.js のホットリロードに対応するために bind volume を行っていたが、node_modulesを別volumeに分けていた。
新しいパッケージをインストールした際などに毎度volumeを削除するのは面倒かつ、エラーの原因になったりとやや厄介な存在だった。

watch の方が node_modules の無視などのケアがやりやすいのでそちらを使いたい。

## :pick: 修正内容 (What)

- bind volume をやめた
- watch できる設定を compose.yaml に書いた
- コンテナビルドする際に ESLint に怒られる場所があったので TODO を書いて無視するようにした。

## :camera_flash: キャプチャ

Before|After
------|-----
画像|画像

## :eyes: 懸案事項

## :mag: チェック項目

このPRで変更が想定通りうまくいっているかを確認するには...

- [ ]
- [ ]
- [ ]
