### PR TITLE
GitHub Container Registry へ push するようにしてみる

### DIFF
--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -64,6 +64,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value={{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}-{{sha}}
           # Open Container Initiative (OCI) の Image Spec に基づくラベル
           # ref:

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -63,6 +63,8 @@ jobs:
         id: meta
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+          # デフォルトブランチの時だけ latest タグをつけてそれ以外は日時とコミットハッシュをつける
+          # ref: https://github.com/docker/metadata-action?tab=readme-ov-file#customizing
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value={{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}-{{sha}}

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -65,8 +65,7 @@ jobs:
           context: ./packages/akane-next
           file: ./docker/akane-next/Dockerfile
           platforms: linux/amd64
-          # push: ${{ github.head_ref == 'main' }}
-          push: true
+          push: ${{ github.head_ref == 'main' }}
           tags: ghcr.io/${{ github.repository_owner }}/2025_9/akene-next:latest
           provenance: false
         env:

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -72,7 +72,7 @@ jobs:
           # ref:
           # - https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/annotations.md?plain=1#L18-L26
           labels: |
-            org.opencontainers.image.created={{date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
+            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]' tz='Asia/Tokyo'}}
             org.opencontainers.image.authors="rokuosan, taiseiue, nenrinyear, Retasusan, ikotome"
             org.opencontainers.image.url="https://github.com/kc3hack/2025_9"
             org.opencontainers.image.documentation="https://github.com/kc3hack/2025_9"

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -64,7 +64,8 @@ jobs:
           context: ./packages/akane-next
           file: ./docker/akane-next/Dockerfile
           platforms: linux/amd64
-          push: ${{ github.head_ref == 'main' }}
+          # push: ${{ github.head_ref == 'main' }}
+          push: true
           tags: ghcr.io/${{ github.repository_owner }}/akene-next:latest
           provenance: false
         env:

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -72,7 +72,7 @@ jobs:
           # ref:
           # - https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/annotations.md?plain=1#L18-L26
           labels: |
-            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
+            org.opencontainers.image.created={{date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
             org.opencontainers.image.authors="rokuosan, taiseiue, nenrinyear, Retasusan, ikotome"
             org.opencontainers.image.url="https://github.com/kc3hack/2025_9"
             org.opencontainers.image.documentation="https://github.com/kc3hack/2025_9"

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -49,6 +49,7 @@ jobs:
       pull-requests: read
       id-token: write
       actions: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,7 +67,7 @@ jobs:
           platforms: linux/amd64
           # push: ${{ github.head_ref == 'main' }}
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/akene-next:latest
+          tags: ghcr.io/${{ github.repository_owner }}/2025_9/akene-next:latest
           provenance: false
         env:
           NODE_ENV: production

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -62,7 +62,7 @@ jobs:
       - uses: docker/metadata-action@v4
         id: meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}/akane-next
           # デフォルトブランチの時だけ latest タグをつけてそれ以外は日時とコミットハッシュをつける
           # ref: https://github.com/docker/metadata-action?tab=readme-ov-file#customizing
           tags: |

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -72,7 +72,7 @@ jobs:
           # ref:
           # - https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/annotations.md?plain=1#L18-L26
           labels: |
-            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]' tz='Asia/Tokyo'}}
+            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS' tz='Asia/Tokyo'}}
             org.opencontainers.image.authors="rokuosan, taiseiue, nenrinyear, Retasusan, ikotome"
             org.opencontainers.image.url="https://github.com/kc3hack/2025_9"
             org.opencontainers.image.documentation="https://github.com/kc3hack/2025_9"

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -72,7 +72,7 @@ jobs:
           # ref:
           # - https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/annotations.md?plain=1#L18-L26
           labels: |
-            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS' tz='Asia/Tokyo'}}
+            org.opencontainers.image.created={{date 'yyyy-MM-ddTHH:mm:ss.SSS' tz='Asia/Tokyo'}}
             org.opencontainers.image.authors="rokuosan, taiseiue, nenrinyear, Retasusan, ikotome"
             org.opencontainers.image.url="https://github.com/kc3hack/2025_9"
             org.opencontainers.image.documentation="https://github.com/kc3hack/2025_9"

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -62,7 +62,7 @@ jobs:
       - uses: docker/metadata-action@v4
         id: meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/{{ github.repository }}
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
           tags: |
             type=raw,value={{branch}}-{{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}
           # Open Container Initiative (OCI) の Image Spec に基づくラベル

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -64,7 +64,16 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/{{ github.repository }}
           tags: |
-            type=semver,pattern={{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}
+            type=raw,value={{branch}}-{{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}
+          # Open Container Initiative (OCI) の Image Spec に基づくラベル
+          # ref:
+          # - https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/annotations.md?plain=1#L18-L26
+          labels: |
+            org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
+            org.opencontainers.image.authors="rokuosan, taiseiue, nenrinyear, Retasusan, ikotome"
+            org.opencontainers.image.url="https://github.com/kc3hack/2025_9"
+            org.opencontainers.image.documentation="https://github.com/kc3hack/2025_9"
+            org.opencontainers.image.source="https://github.com/kc3hack/2025_9"
       - name: Build and push
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -38,3 +38,35 @@ jobs:
         run: npm run lint -w packages/akane-next
       - name: Test
         run: npm run test -w packages/akane-next
+      - name: Build
+        run: npm run build -w packages/akane-next
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./packages/akane-next
+          file: ../../docker/akane-next/Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.head_ref == 'main' }}
+          tags: ghcr.io/${{ github.repository_owner }}/akene-next:latest
+        env:
+          NODE_ENV: production
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./packages/akane-next
-          file: ../../docker/akane-next/Dockerfile
+          file: ./docker/akane-next/Dockerfile
           platforms: linux/amd64
           push: ${{ github.head_ref == 'main' }}
           tags: ghcr.io/${{ github.repository_owner }}/akene-next:latest

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -62,7 +62,7 @@ jobs:
       - uses: docker/metadata-action@v4
         id: meta
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}/akane-next
+          images: ghcr.io/${{ github.repository }}/akane-next
           # デフォルトブランチの時だけ latest タグをつけてそれ以外は日時とコミットハッシュをつける
           # ref: https://github.com/docker/metadata-action?tab=readme-ov-file#customizing
           tags: |

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -72,7 +72,6 @@ jobs:
           # ref:
           # - https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/annotations.md?plain=1#L18-L26
           labels: |
-            org.opencontainers.image.created={{date 'yyyy-MM-ddTHH:mm:ss.SSS' tz='Asia/Tokyo'}}
             org.opencontainers.image.authors="rokuosan, taiseiue, nenrinyear, Retasusan, ikotome"
             org.opencontainers.image.url="https://github.com/kc3hack/2025_9"
             org.opencontainers.image.documentation="https://github.com/kc3hack/2025_9"

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
           tags: |
-            type=raw,value={{branch}}-{{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}
+            type=raw,value={{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}-{{sha}}
           # Open Container Initiative (OCI) の Image Spec に基づくラベル
           # ref:
           # - https://github.com/opencontainers/image-spec/blob/fbb4662eb53b80bd38f7597406cf1211317768f0/annotations.md?plain=1#L18-L26

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -83,7 +83,7 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: ${{ github.head_ref == 'main' }}
+          push: true
           provenance: false
         env:
           NODE_ENV: production

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -59,14 +59,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/{{ github.repository }}
+          tags: |
+            type=semver,pattern={{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: ./packages/akane-next
           file: ./docker/akane-next/Dockerfile
           platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.head_ref == 'main' }}
-          tags: ghcr.io/${{ github.repository_owner }}/2025_9/akene-next:latest
           provenance: false
         env:
           NODE_ENV: production

--- a/.github/workflows/akane-next-test.yaml
+++ b/.github/workflows/akane-next-test.yaml
@@ -66,6 +66,7 @@ jobs:
           platforms: linux/amd64
           push: ${{ github.head_ref == 'main' }}
           tags: ghcr.io/${{ github.repository_owner }}/akene-next:latest
+          provenance: false
         env:
           NODE_ENV: production
       - name: Image digest


### PR DESCRIPTION
# Pull request

- Issues: 

## :question: 背景 (Why)

本番デプロイを簡単にするために GitHub Container Registry にイメージがあると便利だったので公開したかった。

## :pick: 修正内容 (What)

- コンテナイメージがビルドされるように CI を改修した
- main にマージされたときに push されるようにした
- ビルドされるイメージにはビルド日時とコミットハッシュがタグとして付与される

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/2a31c5dd-4f8f-408c-8b0d-4d67ba68656a" />

## :camera_flash: キャプチャ

Before|After
------|-----
画像|画像

## :eyes: 懸案事項

## :mag: チェック項目

このPRで変更が想定通りうまくいっているかを確認するには...

- [ ]
- [ ]
- [ ]
