### PR TITLE
Nextのポートを3800に移動/80ポート待受の廃止

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: ../../docker/akane-next/Dockerfile
     command: ["npm", "run", "dev"]
     ports:
-      - "3000:3000"
+      - "3800:3000"
       - "5555:5555" # for prisma studio
     develop:
       watch:
@@ -19,6 +19,8 @@ services:
           path: package.json
     environment:
       DATABASE_URL: "mysql://root@db:3306/akane"
+    depends_on:
+      - db
 
   nginx:
     image: nginx:latest
@@ -26,10 +28,8 @@ services:
       context: docker/nginx
       dockerfile: ./Dockerfile
     ports:
-      - "80:80"
       - "443:443"
     depends_on:
-      - db
       - akane-next
 
   db:

--- a/docker/nginx/conf.d/local.akane.yaken.org.conf
+++ b/docker/nginx/conf.d/local.akane.yaken.org.conf
@@ -1,13 +1,4 @@
 server {
-    listen       80;
-    server_name  local.akane.yaken.org;
-
-    location / {
-        proxy_pass http://akane-next:3000/;
-    }
-}
-
-server {
     listen 443 ssl;
     server_name  local.akane.yaken.org;
 


### PR DESCRIPTION
# Nextのポートを3800に移動/80ポート待受の廃止

- Issues: 

## :question: 背景 (Why)

今日の夜会でNextの待ち受けポートを3000から3800にずらしてほしいという話があった。
詳しくは下の話を参照。

https://scrapbox.io/kc3hack2025-team09/2025%2F2%2F16_~_2%2F24_%E3%83%81%E3%83%BC%E3%83%A09%E5%A4%9C%E4%BC%9A_%E9%96%8B%E7%99%BA%E6%9C%9F%E9%96%93%E3%81%AF%E5%AF%9D%E3%82%8C%E3%81%BE%E3%81%9B%E3%82%93%E3%82%B9%E3%83%97%E3%83%AA%E3%83%B3%E3%83%88#67b73615fcc892000043afa7

## :pick: 修正内容 (What)

- Nextのポートを3800に移動した
- nginxの80ポート待受を廃止した(HTTPSのみにした)

## :camera_flash: キャプチャ

Before|After
------|-----
画像|画像

## :eyes: 懸案事項

## :mag: チェック項目

このPRで変更が想定通りうまくいっているかを確認するには...

- [ ] `task up`して`https://local.akane.yaken.org/`がみれるか確認してください
- [ ] みれなければ、CA 証明書の再確認が必要かも
- [ ]
