### PR TITLE
管理画面出し分けられるようにした

### DIFF
--- a/docker/nginx/conf.d/admin.local.akane.yaken.org.conf
+++ b/docker/nginx/conf.d/admin.local.akane.yaken.org.conf
@@ -1,0 +1,15 @@
+server {
+    listen 443 ssl;
+    server_name  admin.local.akane.yaken.org;
+
+    ssl_certificate /etc/nginx/certs/admin.local.akane.yaken.org.crt;
+    ssl_certificate_key /etc/nginx/certs/admin.local.akane.yaken.org.key;
+    ssl_session_tickets off;
+    ssl_protocols TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://akane-next:3000/admin/;
+    }
+
+}

--- a/docker/nginx/conf.d/local.akane.yaken.org.conf
+++ b/docker/nginx/conf.d/local.akane.yaken.org.conf
@@ -11,4 +11,9 @@ server {
     location / {
         proxy_pass http://akane-next:3000/;
     }
+
+    location /admin {
+        deny all;
+        return 403;
+    }
 }

--- a/docker/nginx/setup-certs.sh
+++ b/docker/nginx/setup-certs.sh
@@ -3,14 +3,25 @@
 # 有効期限
 EXPIRATION=365 # 1年
 # TLSを有効にするホスト名をカンマ区切りで指定
-AKANE_HOSTS=local.akane.yaken.org
+AKANE_HOSTS=local.akane.yaken.org,admin.local.akane.yaken.org
 
 cd docker/nginx/certs
 
-openssl req -new -x509 -noenc -subj '/C=JP/CN=Yaken Akane Private CA' -days $EXPIRATION -out akane-local-ca.crt -keyout akane-local-ca.key
+if [[ ! -e akane-local-ca.crt ]]; then
+    echo "Creating private CA..."
+    openssl req -new -x509 -noenc -subj '/C=JP/CN=Yaken Akane Private CA' -days $EXPIRATION -out akane-local-ca.crt -keyout akane-local-ca.key
+    echo "[OK] Created private CA."
+else
+    echo "[INFO] Private CA already exists."
+fi
 
 for host in ${AKANE_HOSTS//,/ }; do
-    openssl req -new -noenc -subj "/C=JP/CN=$host" -addext "subjectAltName = DNS:$host" -out "$host.csr" -keyout "$host.key"
-    openssl x509 -req -in "$host.csr" -CA akane-local-ca.crt -CAkey akane-local-ca.key -copy_extensions copy -days $EXPIRATION -out "$host.crt"
-    echo "Created certificate for $host."
+    if [[ ! -e "$host.crt" ]]; then
+        openssl req -new -noenc -subj "/C=JP/CN=$host" -addext "subjectAltName = DNS:$host" -out "$host.csr" -keyout "$host.key"
+        openssl x509 -req -in "$host.csr" -CA akane-local-ca.crt -CAkey akane-local-ca.key -copy_extensions copy -days $EXPIRATION -out "$host.crt"
+        echo "[OK] Created certificate for $host."
+        continue
+    else
+        echo "[INFO] Certificate for $host already exists."
+    fi
 done


### PR DESCRIPTION
# 管理画面出し分けられるようにした

- Issues: close #55

## :question: 背景 (Why)

## :pick: 修正内容 (What)

- `https://local.akane.yaken.org/admin`にアクセスしたときに**403**を返すように
- `https://admin.local.akane.yaken.org/`にアクセスしたときに`/admin`にあるやつが表示されるように
- ドメインを追加でつくったときに、既存のCA証明書を再生成しなくてもいいように

## :camera_flash: キャプチャ

Before|After
------|-----
画像|画像

## :eyes: 懸案事項

## :mag: チェック項目

このPRで変更が想定通りうまくいっているかを確認するには...

- [ ] `task setup`する
- [ ] `https://local.akane.yaken.org/admin`にアクセスしたときに403になることを確認する
- [ ] `https://admin.local.akane.yaken.org/`にアクセスしたときに404になることを確認する
