### PR TITLE
Next.js の Server Action で許可されるドメインを列挙した

### DIFF
--- a/packages/akane-next/next.config.ts
+++ b/packages/akane-next/next.config.ts
@@ -1,11 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  experimental: {
-    optimizePackageImports: [
-      "@chakra-ui/react",
-    ]
-  }
+	experimental: {
+		optimizePackageImports: ["@chakra-ui/react"],
+		serverActions: {
+			allowedOrigins: ["local.akane.yaken.org", "admin.local.akane.yaken.org"],
+		},
+	},
 };
 
 export default nextConfig;

--- a/packages/akane-next/next.config.ts
+++ b/packages/akane-next/next.config.ts
@@ -4,7 +4,17 @@ const nextConfig: NextConfig = {
 	experimental: {
 		optimizePackageImports: ["@chakra-ui/react"],
 		serverActions: {
-			allowedOrigins: ["local.akane.yaken.org", "admin.local.akane.yaken.org"],
+			allowedOrigins: [
+				// 本番環境
+				"akane.yaken.org",
+				"admin-akane.yaken.org",
+				// ステージング環境
+				"st-akane.yaken.org",
+				"admin-st-akane.yaken.org",
+				// ローカル環境
+				"local.akane.yaken.org",
+				"admin.local.akane.yaken.org",
+			],
 		},
 	},
 };


### PR DESCRIPTION
# Pull request

- Issues: 

## :question: 背景 (Why)

Next.js で Server Actions を動かすために許可するホストを明示する必要があった。

Server Actions とかいかにも最新技術ですよみたいな顔をしているが、実のところはただの POST リクエストをする関数を Client Component に渡せるようになっただけのことである。
このプロジェクトでは form の action に書いておくと、勝手に中身が URL に変換されてそこに POST してサーバーサイドでコード実行するというものとして使うことが多い。（その想定をしている）

## :pick: 修正内容 (What)

- production
- staging
- local

上記すべての環境のドメインを allowedOrigins に詰め込んだ

## :camera_flash: キャプチャ

Before|After
------|-----
画像|画像

## :eyes: 懸案事項

## :mag: チェック項目

このPRで変更が想定通りうまくいっているかを確認するには...

- [ ]
- [ ]
- [ ]
