### PR TITLE
Docker Watch で Sync する先を正しくする

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
       watch:
         - action: sync
           path: ./packages/akane-next
-          target: /app
+          target: /app/packages/akane-next
           ignore:
             - node_modules
             - .next


### PR DESCRIPTION
# Pull request

- Issues: 

## :question: 背景 (Why)

Dockerfile で参照するディレクトリ構造を変更したために、compose.yaml の build context を変更していた。
しかし、watch して sync する時のディレクトリが古いままであったため Next.js が watch しているファイルには変更が加わらずホットリロードできなかった。

## :pick: 修正内容 (What)

- 実装方針や作業内容を細かく

## :camera_flash: キャプチャ

Before|After
------|-----
画像|画像

## :eyes: 懸案事項

## :mag: チェック項目

このPRで変更が想定通りうまくいっているかを確認するには...

- [ ]
- [ ]
- [ ]
